### PR TITLE
Use link without variable in wsgi.py to fix cookiecutter generation

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/wsgi.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/wsgi.py
@@ -4,7 +4,7 @@ WSGI config for {{ cookiecutter.project_slug }} project.
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/{{ docs_version }}/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/stable/howto/deployment/wsgi/
 """
 
 import os


### PR DESCRIPTION
Without this fix cookiecutter 1.4.0 fails with the following error:

Unable to create file '{{cookiecutter.project_slug}}/wsgi.py'
Error message: 'docs_version' is undefined
Context: {
    "cookiecutter": {
        "project_slug": "my_project", 
        "use_drifter": "n"
    }
}
