### PR TITLE
Fix wsgi import path

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/wsgi.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/wsgi.py
@@ -11,7 +11,7 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-from . import get_project_root_path, import_env_vars
+from {{ cookiecutter.project_slug }}.config import get_project_root_path, import_env_vars
 
 import_env_vars(os.path.join(get_project_root_path(), 'envdir'))
 


### PR DESCRIPTION
This fixes the import for `get_project_root_path` and `import_env_vars` in `wsgi.py`