### PR TITLE
WIP: Install proper logging levels and handlers

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/log_filters.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/log_filters.py
@@ -1,0 +1,8 @@
+import logging
+
+
+class InfoLogFilter(logging.Filter):
+
+    def filter(self, record):
+        """Only let records through that have log level INFO"""
+        return record.levelno == logging.INFO


### PR DESCRIPTION
Install proper logging handlers. The main change is that INFO and ERROR
log are two separate files, which I feel is the correct way to handle
this. In my opinion, INFO messages should be used to really log what's going
on on the system like API calls.

The settings all in all now meet following requirements:

* Debug log messages are only logged to the console and only if DEBUG is
  set to True (this is to avoid spamming the uwsgi log or something on
  the server)
* Info log messages are logged into the file set by the environment
  variable INFO_LOG_FILE. Only info log level is stored into this file.
* WARNING, ERROR and CRITICAL messages are stored in the file set by the
  ERROR_LOG_FILE environment variable
* ERROR and CRITICAL are also sent by email to the list of ADMINS in the
  settings, but only if DEBUG is set to False (i.e. on the remote
  systems)