### PR TITLE
Advanced logging configuration

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/log_filters.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/log_filters.py
@@ -1,0 +1,8 @@
+import logging
+
+
+class InfoLogFilter(logging.Filter):
+
+    def filter(self, record):
+        """Only let records through that have log level INFO"""
+        return record.levelno == logging.INFO

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -236,10 +236,6 @@ AUTH_USER_MODEL = 'accounts.User'
 # LOGGING #
 ###########
 
-###########
-# LOGGING #
-###########
-
 _PROJECT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                             '../../../')
 
@@ -253,7 +249,7 @@ LOGGING = {
     'disable_existing_loggers': True,
     'filters': {
         'info_only': {
-            '()': 'energyday17.log_filters.InfoLogFilter'
+            '()': '{{ cookiecutter.project_slug }}.config.log_filters.InfoLogFilter'
         },
         'require_debug_false': {
             '()': 'django.utils.log.RequireDebugFalse'

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -236,20 +236,80 @@ AUTH_USER_MODEL = 'accounts.User'
 # LOGGING #
 ###########
 
+###########
+# LOGGING #
+###########
+
+_PROJECT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            '../../../')
+
+ERROR_LOG_FILE = get_env_variable('ERROR_LOG_FILE',
+                                  os.path.join(_PROJECT_DIR, 'error_log'))
+INFO_LOG_FILE = get_env_variable('INFO_LOG_FILE',
+                                 os.path.join(_PROJECT_DIR, 'info_log'))
+
 LOGGING = {
     'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'console': {
-            'level': 'INFO',
-            'class': 'logging.StreamHandler',
+    'disable_existing_loggers': True,
+    'filters': {
+        'info_only': {
+            '()': 'energyday17.log_filters.InfoLogFilter'
         },
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse'
+        },
+        'require_debug_true': {
+            '()': 'django.utils.log.RequireDebugTrue'
+        }
+    },
+    'handlers': {
+        'info_file': {
+            'level': 'INFO',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': INFO_LOG_FILE,
+            'maxBytes': 1024 * 1024 * 5,  # 5 MB
+            'backupCount': 5,
+            'formatter': 'default',
+            'filters': ['info_only']
+        },
+        'error_file': {
+            'level': 'WARNING',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': ERROR_LOG_FILE,
+            'maxBytes': 1024 * 1024 * 5,  # 5 MB
+            'backupCount': 5,
+            'formatter': 'default',
+        },
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'default',
+            'filters': ['require_debug_true']
+        },
+        'mail_admins': {
+            'level': 'ERROR',
+            'class': 'django.utils.log.AdminEmailHandler',
+            'filters': ['require_debug_false']
+        }
     },
     'loggers': {
         '': {
+            'handlers': ['error_file', 'info_file', 'console', 'mail_admins'],
+            'level': 'DEBUG',
+        },
+        'django': {
+            'handlers': ['error_file', 'info_file', 'console', 'mail_admins'],
+            'level': 'DEBUG',
+        },
+        'django.db.backends': {
             'handlers': ['console'],
             'level': 'ERROR',
-            'propagate': True,
+            'propagate': False,
         },
     },
+    'formatters': {
+        'default': {
+            'format': '%(asctime)s %(module)s %(message)s'
+        },
+    }
 }


### PR DESCRIPTION
In debug mode, this configuration logs to the console on DEBUG level (excluding database queries)
In production mode there are two log files created, one which only contains INFO level log statements and the other only ERROR and higher levels.

Question: What should the default log file location be? We (aka @liip/amboss ) set these variables with django-ansible and it also works in drifter, but probably on some servers these directories are not writable by the app server. Probably a /tmp/ would probably be better?

Replaces #20.