### PR TITLE
Use drifter default pip tools version

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -36,7 +36,6 @@ def patch_parameters(path):
     set_parameter(path, 'database_name', '{{ cookiecutter.project_slug }}')
     set_parameter(path, 'hostname', "{{ cookiecutter.project_slug.replace('_', '-') }}.lo")
     set_parameter(path, 'python_version', '3')
-    set_parameter(path, 'pip_tools_version', '1.11.0')
 
 
 def patch_playbook(path):


### PR DESCRIPTION
With latest Drifter release (1.7.0) `pip-tools >= 2.0` is required.
We should use Drifter's default by removing template's `set_parameter`.