### PR TITLE
Add an option for drifter's debian version

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,9 +1,10 @@
 {
-	"project_slug": "my_project",
-    "use_drifter": "y",
-    "override_user_model": "y",
-    "use_djangocms": "n",
-    "_copy_without_render": [
-        "*.html"
-    ]
+  "project_slug": "my_project",
+  "use_drifter": "y",
+  "debian_version": ["jessie", "stretch"],
+  "override_user_model": "y",
+  "use_djangocms": "n",
+  "_copy_without_render": [
+    "*.html"
+  ]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -36,6 +36,8 @@ def patch_parameters(path):
     set_parameter(path, 'database_name', '{{ cookiecutter.project_slug }}')
     set_parameter(path, 'hostname', "{{ cookiecutter.project_slug.replace('_', '-') }}.lo")
     set_parameter(path, 'python_version', '3')
+    set_parameter(path, 'box_name', 'drifter/{{ cookiecutter.debian_version }}64-base')
+    set_parameter(path, 'box_url', 'https://vagrantbox-public.liip.ch/drifter-{{ cookiecutter.debian_version }}64-base.json')
 
 
 def patch_playbook(path):

--- a/{{cookiecutter.project_slug}}/tox.ini
+++ b/{{cookiecutter.project_slug}}/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34
+envlist = {% if cookiecutter.debian_version == 'stretch' %}py35{% else %}py34{% endif %}
 skipsdist = True
 
 [base]


### PR DESCRIPTION
I left Jessie as the default choice, but we can now select Stretch if we would like to.