### PR TITLE
Fix exit status of check_migrations.sh

### DIFF
--- a/{{cookiecutter.project_slug}}/scripts/check_migrations.sh
+++ b/{{cookiecutter.project_slug}}/scripts/check_migrations.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
 echo "Checking for missing migrations"
-./manage.py makemigrations --dry-run --check --no-input -v1 || (echo "Missing migrations detected!" && exit 1)
-exit 0
+if ! ./manage.py makemigrations --dry-run --check --no-input -v1; then
+  echo "Missing migrations detected!"
+  exit 1
+fi


### PR DESCRIPTION
70e116829f7b756fe5b4bdeff0d5996749b39f0e caused a regressionin the `check_migrations.sh` script.
The `exit 1` instruction now runs is a subshell, which means only the subshell exits (with the status 1). Then `exit 0 ` runs in every case.
A quick solution would be to replace `exit 0` with `exit $?`. However I think an `if` clause is more readable in this case.