### PR TITLE
Use MiniCssExtractPlugin in dev and prod

### DIFF
--- a/{{cookiecutter.project_slug}}/webpack.config.js
+++ b/{{cookiecutter.project_slug}}/webpack.config.js
@@ -33,7 +33,10 @@ module.exports = {
         test: /\.scss$/,
         use: [
           {
-            loader: process.env.NODE_ENV === 'production' ? MiniCssExtractPlugin.loader : 'style-loader',
+            loader: MiniCssExtractPlugin.loader,
+            options: {
+              hmr: process.env.NODE_ENV === 'development',
+            },
           },
           'css-loader',
           {
@@ -88,9 +91,6 @@ module.exports = {
     proxy: {
       '**': {
         target: 'http://{{ cookiecutter.project_slug|replace('_', '-') }}.lo',
-        headers: {
-          'x-webpack-dev-server': 'yes',
-        },
       },
     },
     public: '{{ cookiecutter.project_slug|replace('_', '-') }}.lo:3000',

--- a/{{cookiecutter.project_slug}}/webpack.config.js
+++ b/{{cookiecutter.project_slug}}/webpack.config.js
@@ -2,7 +2,6 @@
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const SpriteLoaderPlugin = require('svg-sprite-loader/plugin');
-const browserslist = require('./package.json').browserslist;
 
 module.exports = {
   mode: process.env.NODE_ENV,

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -157,8 +157,6 @@ TEMPLATES = [
                 "sekizai.context_processors.sekizai",
                 "cms.context_processors.cms_settings",
                 {%- endif %}
-
-                "{{ cookiecutter.project_slug }}.core.context_processors.webpack_dev_server",
             ],
             "loaders": [
                 (

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/core/context_processors.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/core/context_processors.py
@@ -1,4 +1,0 @@
-def webpack_dev_server(request):
-    return {
-        "webpack_dev_server": request.META.get("HTTP_X_WEBPACK_DEV_SERVER") == "yes"
-    }

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
@@ -5,10 +5,7 @@
     <meta charset="UTF-8">
     <title></title>
 
-    {# In development, stylesheets are injected by webpack-dev-server #}
-    {% if not webpack_dev_server %}
     <link rel="stylesheet" type="text/css" href="{% static 'dist/common.css' %}">
-    {% endif %}
   </head>
   <body>
     {% block body %}


### PR DESCRIPTION
MiniCssExtractPlugin supports hot module reloading since v0.6.0.

See https://github.com/liip/styleguide-starterkit/commit/75d0fffdd5cf940c4ff0880526034083cf5c1601

**Blocker**: This won't work out of the box until drifter's package.json template gets updated.
https://github.com/liip/drifter/blob/master/provisioning/roles/nodejs/templates/package.json.webpack.j2#L19

Drifter PR: https://github.com/liip/drifter/pull/271
