### PR TITLE
Add PostGIS support to database operations in fabfile

### DIFF
--- a/{{cookiecutter.project_slug}}/fabfile.py
+++ b/{{cookiecutter.project_slug}}/fabfile.py
@@ -366,7 +366,10 @@ def clean_old_database_backups(nb_backups_to_keep):
 
 
 def is_supported_db_engine(engine):
-    return engine == "django.db.backends.postgresql_psycopg2"
+    return engine in (
+        "django.db.backends.postgresql_psycopg2",
+        "django.contrib.gis.db.backends.postgis",
+    )
 
 
 # Environment handling stuff


### PR DESCRIPTION
This mini-PR adds PostGIS as supported database backend to the fabfile.
This was just tested on homebytwo.ch. Thank you for your hard and helpful work.