### PR TITLE
Webpack: Do not clean the .gitkeep file

### DIFF
--- a/{{cookiecutter.project_slug}}/webpack.config.js
+++ b/{{cookiecutter.project_slug}}/webpack.config.js
@@ -78,7 +78,9 @@ module.exports = {
       filename: '[name].css',
     }),
     new SpriteLoaderPlugin(),
-    new CleanWebpackPlugin(),
+    new CleanWebpackPlugin({
+        cleanOnceBeforeBuildPatterns: ['**/*', '!.gitkeep'],
+    }),
   ],
   devServer: {
     proxy: {


### PR DESCRIPTION
When routinely `npm run build`ing, the removal of the `static/dist/.gitkeep` file is a useless annoyance.