### PR TITLE
Set DEFAULT_AUTO_FIELD

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/accounts/apps.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/accounts/apps.py
@@ -2,4 +2,5 @@ from django.apps import AppConfig
 
 
 class AccountsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
     name = "{{ cookiecutter.project_slug }}.accounts"


### PR DESCRIPTION
This gets rid of a Django warning introduced in 3.2:
https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field