### PR TITLE
Simpler way to share SSH keys from non-Linux hosts

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -24,7 +24,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN set -x; \
     groupadd -g $GROUP_ID app && \
     useradd --create-home -u $USER_ID -g app -s /bin/bash app && \
-    install -o app -g app -d /code "$VIRTUAL_ENV"
+    install -o app -g app -d /code "$VIRTUAL_ENV" /home/app/.ssh
 USER app
 RUN python -m venv "$VIRTUAL_ENV"
 WORKDIR /code

--- a/{{cookiecutter.project_slug}}/docker-compose.override.example.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.override.example.yml
@@ -25,7 +25,7 @@
 #     ports:
 #       - 127.0.0.1:8025:8025
 
-# PONTSUN CONFIGURATION
+# EXTENDED CONFIGURATION (pontsun, SSH access)
 # ~~~~~~~~~~~~~~~~~~~~~
 #
 # Set up pontsun (https://github.com/liip/pontsun) and start it. Then visit
@@ -48,6 +48,9 @@
 #       SSH_AUTH_SOCK: /ssh-agent
 #     volumes:
 #       - $SSH_AUTH_SOCK:/ssh-agent
+#       # SSH agent forwarding only works with Linux hosts
+#       # On Windows and macOS, you have to mount the private key directly:
+#       # - ~/.ssh/id_rsa:/home/app/.ssh/id_rsa
 #     build:
 #       args:
 #         <<: *x-build-args

--- a/{{cookiecutter.project_slug}}/fabfile.py
+++ b/{{cookiecutter.project_slug}}/fabfile.py
@@ -552,10 +552,12 @@ def create_environment_task(name, env_conf):
         conf["environment"] = name
         # So now conf is the ENVIRONMENTS[env] dict plus "environment" pointing to the name
         # Push them in the context config dict
-        ctx.config.load_overrides(conf)
-        # Add the common_settings in there
-        ctx.conn = CustomConnection(host=conf["host"], inline_ssh_env=True)
-        ctx.conn.config.load_overrides(conf)
+        ctx.config.update(conf)
+        # Create a connection for this environment,
+        # sharing most of the configuration with the root context
+        ctx.conn = CustomConnection(
+            config=ctx.config.clone(), host=conf["host"], inline_ssh_env=True
+        )
 
     load_environment.__doc__ = (
         """Prepare connection and load config for %s environment""" % name


### PR DESCRIPTION
Using fabric without an agent is painful but much easier to setup than a shared SSH agent.