### PR TITLE
Upgrade versions of docker-compose, OSes, python and node

### DIFF
--- a/{{cookiecutter.project_slug}}/.gitlab-ci.yml
+++ b/{{cookiecutter.project_slug}}/.gitlab-ci.yml
@@ -5,7 +5,7 @@ test:
   stage: test
   tags:
     - docker-nonswiss-ok
-  image: &test_image 'python:3.7.4-buster'
+  image: &test_image 'python:3.9-bullseye'
   services:
     - name: postgres:11.8
       alias: db

--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.7-buster
+FROM python:3.9-bullseye
 
 # Needed to build assets in the deployment process
 RUN set -x; \
     export DEBIAN_FRONTEND=noninteractive \
-    && echo "deb https://deb.nodesource.com/node_10.x buster main" > /etc/apt/sources.list.d/nodesource.list \
+    && echo "deb https://deb.nodesource.com/node_16.x bullseye main" > /etc/apt/sources.list.d/nodesource.list \
     && curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
     && apt-get update -qq \
     && apt-get install -yq \

--- a/{{cookiecutter.project_slug}}/Dockerfile-frontend
+++ b/{{cookiecutter.project_slug}}/Dockerfile-frontend
@@ -1,4 +1,4 @@
-FROM node:10-buster
+FROM node:16-bullseye
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000

--- a/{{cookiecutter.project_slug}}/docker-compose.override.example.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.override.example.yml
@@ -13,7 +13,7 @@
 #
 # Visit http://localhost:8025 to access the project's fake mail box.
 #
-# version: '3.4'
+# version: '3.8'
 # services:
 #   backend:
 #     ports:
@@ -33,7 +33,7 @@
 #
 # Visit https://{{ subdomain }}-mail.docker.test/ to access the project's fake mail box.
 #
-# version: '3.4'
+# version: '3.8'
 # x-environment:
 #   &x-environment
 #   ALLOWED_HOSTS: >-
@@ -82,7 +82,6 @@
 #       - 'traefik.frontend.rule=Host:{{ subdomain }}-mail.docker.test'
 # networks:
 #   pontsun:
-#     external:
-#       name: pontsun
+#     external: true
 # volumes:
 #   media:

--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '3.8'
 
 x-environment:
   &x-environment
@@ -19,6 +19,7 @@ services:
     build:
       context: .
     command: sh -c 'while true; do ./manage.py runserver 0.0.0.0:8000; sleep 1; done'
+    init: true
     environment:
       <<: *x-environment
       ALLOWED_HOSTS: >-
@@ -41,6 +42,7 @@ services:
       context: .
       dockerfile: Dockerfile-frontend
     command: npm start
+    init: true
     volumes:
       - .:/code
     ports:


### PR DESCRIPTION
:information_source:  Upgrade of node and JS dependencies is always in progress in https://github.com/liip/django-template/pull/108. However I also had to upgrade node in this MR because there is no official container image for node 10 on debian bullseye.