### PR TITLE
Fix false-positive warning from debug toolbar

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -91,6 +91,13 @@ CMS_PERMISSION = True
 CMS_PLACEHOLDER_CONF = {}
 
 {% endif %}
+
+SILENCED_SYSTEM_CHECKS = [
+    # False positive: we don't need to set `APP_DIRS=True` in template config
+    # because we already manually specify the "app_directories" loader.
+    "debug_toolbar.W006",
+]
+
 #############
 # DATABASES #
 #############


### PR DESCRIPTION
We don't need to set `APP_DIRS=True` in template config
because we already manually specify the "app_directories" loader.