### PR TITLE
Improve python linting configuration

### DIFF
--- a/{{cookiecutter.project_slug}}/.editorconfig
+++ b/{{cookiecutter.project_slug}}/.editorconfig
@@ -7,7 +7,7 @@ indent_size = 2
 end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
-max_line_length = 120
+max_line_length = 88
 
 [*.{py,php,md}]
 indent_size = 4

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -27,6 +27,13 @@ translations: ## Regenerate .po files with ./manage.py makemessages
 compile-translations: ## Compile .po files with ./manage.py compilemessages
 	./manage.py compilemessages
 
+format:  # Fix some linting issues in the project
+	black {{ cookiecutter.project_slug }} fabfile.py
+	isort {{ cookiecutter.project_slug }} fabfile.py
+
+lint:  # Show linting issues in the project
+	flake8 {{ cookiecutter.project_slug }} fabfile.py
+
 .PHONY: help
 help: ## Display this help
 	@grep -E '^[.a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort -k 1,1 | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.black]
+target-version = ['py39']
+include = '\.pyi?$'
+exclude = '''
+(
+      /\..*
+    | /node_modules/
+    | /migrations/
+    | /static/
+)
+'''

--- a/{{cookiecutter.project_slug}}/requirements/test.in
+++ b/{{cookiecutter.project_slug}}/requirements/test.in
@@ -1,5 +1,6 @@
 -r base.in
 
+black
 factory_boy
 flake8
 flake8-black

--- a/{{cookiecutter.project_slug}}/scripts/run_tests.sh
+++ b/{{cookiecutter.project_slug}}/scripts/run_tests.sh
@@ -11,4 +11,4 @@ set -e
 
 pytest "${@:-{{ cookiecutter.project_slug }}}"
 
-flake8 {{ cookiecutter.project_slug }}
+flake8 {{ cookiecutter.project_slug }} fabfile.py

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -6,13 +6,11 @@ max-line-length = 88
 exclude= */migrations/, {{cookiecutter.project_slug}}/config/settings/, {% if cookiecutter.virtualization_tool == 'drifter' %}virtualization/, {% endif %}manage.py, node_modules, .git
 per-file-ignores =
     {{cookiecutter.project_slug }}/settings/*:F405,F403
-ignore = W, E501, E231
+# Let black handle formatting
+ignore = W, E203, E231, E501
 
 [isort]
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
+profile = black
 known_first_party = {{ cookiecutter.project_slug }}
 known_django = django
 default_section = THIRDPARTY

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/settings/__init__.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/settings/__init__.py
@@ -1,4 +1,5 @@
 import os
+
 from django.core.exceptions import ImproperlyConfigured
 
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -1,12 +1,12 @@
 import os
 
-import dj_database_url
-import dj_email_url
 from django.utils.translation import gettext_lazy as _
 
+import dj_database_url
+import dj_email_url
 
-from . import get_env_variable
 from .. import get_project_root_path
+from . import get_env_variable
 
 gettext = lambda s: s
 
@@ -147,7 +147,7 @@ TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [
-            os.path.join(BASE_DIR, "{{ cookiecutter.project_slug }}", "templates")
+            os.path.join(BASE_DIR, "{{ cookiecutter.project_slug }}", "templates"),
         ],
         "OPTIONS": {
             "context_processors": [


### PR DESCRIPTION
- Add 'format' and 'lint' targets in Makefile
- Use isort with 'black' profile
- Add exclusion list for black
- Also format/lint fabfile.py

:information_source: The first commit contains configuration changes and the second one contains fixes for linting issues raised by flake8 and black.