### PR TITLE
Configure SECURE_PROXY_SSL_HEADER

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -60,6 +60,8 @@ FILE_UPLOAD_PERMISSIONS = 0o644
 
 ALLOWED_HOSTS = tuple(get_env_variable("ALLOWED_HOSTS", "").splitlines())
 
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 SECRET_KEY = get_env_variable("SECRET_KEY", "")
 
 PASSWORD_HASHERS = [


### PR DESCRIPTION
Without this, admin site login doesn't work locally.