### PR TITLE
feat: auto-load common tags in templates

### DIFF
--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -126,7 +126,8 @@ TEMPLATES = [
                 "django.template.context_processors.csrf",
                 "django.template.context_processors.tz",
                 "django.template.context_processors.static",
-            ]
+            ],
+            "builtins": ["django.templatetags.i18n", "django.templatetags.static"],
         },
     }
 ]

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/templates/base.html
@@ -1,4 +1,3 @@
-{% load static %}
 <!DOCTYPE html>
 <html>
   <head>


### PR DESCRIPTION
So that `{% load i18n static %}` isn’t required in templates anymore.